### PR TITLE
Refactor: link models to profile not user

### DIFF
--- a/app/models/app_feedback.rb
+++ b/app/models/app_feedback.rb
@@ -1,3 +1,3 @@
 class AppFeedback < ApplicationRecord
-  belongs_to :user
+  belongs_to :profile
 end

--- a/app/models/app_feedback.rb
+++ b/app/models/app_feedback.rb
@@ -1,3 +1,4 @@
 class AppFeedback < ApplicationRecord
   belongs_to :profile
+  has_one :user, through: :profile
 end

--- a/app/models/buddy_up.rb
+++ b/app/models/buddy_up.rb
@@ -1,8 +1,9 @@
 class BuddyUp < ApplicationRecord
-  belongs_to :user
+  belongs_to :profile
   belongs_to :challenge
   has_many :requests, dependent: :destroy
+  has_many :feedbacks
 
-  validates :name, :description, :challenge, :user, presence: true
+  validates :name, :description, :challenge, :profile, presence: true
   enum :status, { active: 0, archived: 1, complete: 2 }, default: :active
 end

--- a/app/models/buddy_up.rb
+++ b/app/models/buddy_up.rb
@@ -3,6 +3,7 @@ class BuddyUp < ApplicationRecord
   belongs_to :challenge
   has_many :requests, dependent: :destroy
   has_many :feedbacks
+  has_one :user, through: :profile
 
   validates :name, :description, :challenge, :profile, presence: true
   enum :status, { active: 0, archived: 1, complete: 2 }, default: :active

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,6 +1,6 @@
 class Feedback < ApplicationRecord
   belongs_to :buddy_up
-  belongs_to :user
+  belongs_to :profile
 
   validates :work_again, presence: true
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,6 +1,7 @@
 class Feedback < ApplicationRecord
   belongs_to :buddy_up
   belongs_to :profile
+  has_one :user, through: :profile
 
   validates :work_again, presence: true
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,6 +1,10 @@
 class Profile < ApplicationRecord
   belongs_to :user
-  has_many :profile_languages
+  has_many :profile_languages, dependent: :destroy
   has_many :languages, through: :profile_languages
+  has_many :feedbacks
+  has_many :buddy_ups
+  has_many :requests, dependent: :destroy
+
   validates :batch, presence: true
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,7 +1,7 @@
 class Request < ApplicationRecord
   belongs_to :buddy_up
-  belongs_to :user
+  belongs_to :profile
 
-  validates :status, presence: true
+  validates :status, :profile, presence: true
   enum :status, { requested: 0, approved: 1, denied: 2 }, default: :requested
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,6 +1,7 @@
 class Request < ApplicationRecord
   belongs_to :buddy_up
   belongs_to :profile
+  has_one :user, through: :profile
 
   validates :status, :profile, presence: true
   enum :status, { requested: 0, approved: 1, denied: 2 }, default: :requested

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,8 +7,7 @@ class User < ApplicationRecord
 
   enum :status, [ :active, :dummy, :away ]
   has_one :profile
-  has_many :social_links
-  has_many :requests, dependent: :destroy
+  has_many :social_links, dependent: :destroy
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|

--- a/app/views/app_feedbacks/index.html.erb
+++ b/app/views/app_feedbacks/index.html.erb
@@ -7,6 +7,7 @@
   <div>
     <p>Title: <%= app_feedback.title %></p>
     <p>Contents: <%= app_feedback.contents %></p>
+    <% if app_feedback %>
     <p>User: <%= app_feedback.user.email %></p>
   </div>
 <% end %>

--- a/app/views/app_feedbacks/index.html.erb
+++ b/app/views/app_feedbacks/index.html.erb
@@ -7,7 +7,6 @@
   <div>
     <p>Title: <%= app_feedback.title %></p>
     <p>Contents: <%= app_feedback.contents %></p>
-    <% if app_feedback %>
     <p>User: <%= app_feedback.user.email %></p>
   </div>
 <% end %>

--- a/db/migrate/20230830132655_remove_user_from_feedback.rb
+++ b/db/migrate/20230830132655_remove_user_from_feedback.rb
@@ -1,0 +1,6 @@
+class RemoveUserFromFeedback < ActiveRecord::Migration[7.0]
+  def change
+    remove_reference :feedbacks, :user, foreign_key: true, index: true
+    add_reference :feedbacks, :profile, foreign_key: true
+  end
+end

--- a/db/migrate/20230830135418_remove_user_from_buddy_up.rb
+++ b/db/migrate/20230830135418_remove_user_from_buddy_up.rb
@@ -1,0 +1,6 @@
+class RemoveUserFromBuddyUp < ActiveRecord::Migration[7.0]
+  def change
+    remove_reference :buddy_ups, :user, foreign_key: true, index: true
+    add_reference :buddy_ups, :profile, foreign_key: true
+  end
+end

--- a/db/migrate/20230830140330_remove_user_from_requests.rb
+++ b/db/migrate/20230830140330_remove_user_from_requests.rb
@@ -1,0 +1,6 @@
+class RemoveUserFromRequests < ActiveRecord::Migration[7.0]
+  def change
+    remove_reference :requests, :user, foreign_key: true, index: true
+    add_reference :requests, :profile, foreign_key: true
+  end
+end

--- a/db/migrate/20230830141411_remove_user_from_app_feedbacks.rb
+++ b/db/migrate/20230830141411_remove_user_from_app_feedbacks.rb
@@ -1,0 +1,6 @@
+class RemoveUserFromAppFeedbacks < ActiveRecord::Migration[7.0]
+  def change
+    remove_reference :app_feedbacks, :user, foreign_key: true, index: true
+    add_reference :app_feedbacks, :profile, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_13_105536) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_30_141411) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,10 +18,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_13_105536) do
     t.string "title"
     t.text "contents"
     t.datetime "datetime"
-    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_app_feedbacks_on_user_id"
+    t.bigint "profile_id"
+    t.index ["profile_id"], name: "index_app_feedbacks_on_profile_id"
   end
 
   create_table "buddy_ups", force: :cascade do |t|
@@ -31,12 +31,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_13_105536) do
     t.integer "status"
     t.text "availability"
     t.integer "favourites"
-    t.bigint "user_id", null: false
     t.bigint "challenge_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "profile_id"
     t.index ["challenge_id"], name: "index_buddy_ups_on_challenge_id"
-    t.index ["user_id"], name: "index_buddy_ups_on_user_id"
+    t.index ["profile_id"], name: "index_buddy_ups_on_profile_id"
   end
 
   create_table "challenges", force: :cascade do |t|
@@ -51,12 +51,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_13_105536) do
   create_table "feedbacks", force: :cascade do |t|
     t.boolean "work_again", null: false
     t.bigint "buddy_up_id", null: false
-    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "message"
+    t.bigint "profile_id"
     t.index ["buddy_up_id"], name: "index_feedbacks_on_buddy_up_id"
-    t.index ["user_id"], name: "index_feedbacks_on_user_id"
+    t.index ["profile_id"], name: "index_feedbacks_on_profile_id"
   end
 
   create_table "languages", force: :cascade do |t|
@@ -90,11 +90,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_13_105536) do
     t.integer "status", null: false
     t.text "message"
     t.bigint "buddy_up_id", null: false
-    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "profile_id"
     t.index ["buddy_up_id"], name: "index_requests_on_buddy_up_id"
-    t.index ["user_id"], name: "index_requests_on_user_id"
+    t.index ["profile_id"], name: "index_requests_on_profile_id"
   end
 
   create_table "social_links", force: :cascade do |t|
@@ -124,15 +124,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_13_105536) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "app_feedbacks", "users"
+  add_foreign_key "app_feedbacks", "profiles"
   add_foreign_key "buddy_ups", "challenges"
-  add_foreign_key "buddy_ups", "users"
+  add_foreign_key "buddy_ups", "profiles"
   add_foreign_key "feedbacks", "buddy_ups"
-  add_foreign_key "feedbacks", "users"
+  add_foreign_key "feedbacks", "profiles"
   add_foreign_key "profile_languages", "languages"
   add_foreign_key "profile_languages", "profiles"
   add_foreign_key "profiles", "users"
   add_foreign_key "requests", "buddy_ups"
-  add_foreign_key "requests", "users"
+  add_foreign_key "requests", "profiles"
   add_foreign_key "social_links", "users"
 end

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -79,7 +79,7 @@ puts "Creating Feedbacks..."
 BuddyUp.where(status: :complete).each do |buddy_up|
   feedback = Feedback.new(message: "Thanks, that was great!", work_again: true)
   feedback.buddy_up = buddy_up
-  feedback.user = buddy_up.requests.first.user
+  feedback.profile = buddy_up.requests.first.profile
   feedback.save
 end
 puts "...done. #{Feedback.all.count} Feedbacks added to the database."

--- a/db/seeds/partials/_app_feedbacks.rb
+++ b/db/seeds/partials/_app_feedbacks.rb
@@ -2,19 +2,19 @@ app_feedback = AppFeedback.new(title: "Slow!!!",
                                contents: "This app is not nearly fast enough.
                                          Kitt sets a standard you should aspire
                                          to.")
-app_feedback.user = User.all.sample
+app_feedback.profile = Profile.all.sample
 app_feedback.datetime = Time.now - 20000000
 app_feedback.save
 
 app_feedback = AppFeedback.new(title: "So pretty",
                                contents: "Thank you for making a beautifull app.")
-app_feedback.user = User.all.sample
+app_feedback.profile = Profile.all.sample
 app_feedback.datetime = Time.now - 15000000
 app_feedback.save
 
 app_feedback = AppFeedback.new(title: "Broken link",
                                contents: "When I click on Messages in the nav
                                          it goes to my profile page.")
-app_feedback.user = User.all.sample
+app_feedback.profile = Profile.all.sample
 app_feedback.datetime = Time.now - 10000000
 app_feedback.save

--- a/db/seeds/partials/_buddy_ups.rb
+++ b/db/seeds/partials/_buddy_ups.rb
@@ -3,35 +3,35 @@
 
 # Auto-match false, and status active
 buddy_up = BuddyUp.new(name: "It did not come together in Rails.", description: "I want to try the stupid coaching challenge in rails again since things don't quite make sense to me. Looking for someone that will have time to do this in a Slack Hustle and maybe explain some of the concepts as we go.", auto_match: false, availability: "Weekends 8am – 5pm", favourites: 8)
-buddy_up.user = User.where(email: "shane@shane.com").first
+buddy_up.profile = User.where(email: "shane@shane.com").first.profile
 buddy_up.challenge = Challenge.where(["module = ? and name = ?", "Rails", "Stupid Coaching"]).first
 buddy_up.save
 buddy_up = BuddyUp.new(name: "Random code things!", description: "Just feel like trying out a random challenge so I chose this one. See ya soon!!", auto_match: false, availability: "Mondays and Wednesdays, 11:00 to 16:00", favourites: 2)
-buddy_up.user = User.where(email: "joni@joni.com").first
+buddy_up.profile = User.where(email: "joni@joni.com").first.profile
 buddy_up.challenge = Challenge.all.sample
 buddy_up.save
 # Auto-match true and status active
 buddy_up = BuddyUp.new(name: "Pick me, pick me", description: "This challenge really got me during the bootcamp so I want to give it another try.", auto_match: true, availability: "Fridays, just after midnight for an hour or two", favourites: 0)
-buddy_up.user = User.where(email: "joni@joni.com").first
+buddy_up.profile = User.where(email: "joni@joni.com").first.profile
 buddy_up.challenge = Challenge.all.sample
 buddy_up.save
 buddy_up = BuddyUp.new(name: "For those idle evenings", description: "I have some free time in the evenings and thought I'd fill the time with some challenges. This particular one was chosen at random.", auto_match: true, availability: "Weekday evenings after 7pm until late", favourites: 1)
-buddy_up.user = User.where(email: "mitch@mitch.com").first
+buddy_up.profile = User.where(email: "mitch@mitch.com").first.profile
 buddy_up.challenge = Challenge.all.sample
 buddy_up.save
 buddy_up = BuddyUp.new(name: "Catching up", description: "After bootcamp I had to return to my job and never really had time to code. Looking to get back into it now by doing some of the challenges again.", auto_match: true, availability: "All day Sunday.", favourites: 4)
-buddy_up.user = User.where(email: "kira@kira.com").first
+buddy_up.profile = User.where(email: "kira@kira.com").first.profile
 buddy_up.challenge = Challenge.all.sample
 buddy_up.save
 # Auto-match true and status archived
 buddy_up = BuddyUp.new(name: "Help me help myself", description: "Have been struggling with this challenge for a while but just cannot figure it out. I have forked it on Github and if you join we can just jump in since I have the basics in there already.", auto_match: true, availability: "Weekends", favourites: 94)
-buddy_up.user = User.where(email: "shane@shane.com").first
+buddy_up.profile = User.where(email: "shane@shane.com").first.profile
 buddy_up.challenge = Challenge.all.sample
 buddy_up.save
 buddy_up.archived!
 # Auto-match true and status complete
 buddy_up = BuddyUp.new(name: "I want to break things", description: "Thought I'd make a challenge that will auto-match but shouldn't since it is complete.", auto_match: true, availability: "Like, whenever dude.", favourites: 4831)
-buddy_up.user = User.where(email: "kira@kira.com").first
+buddy_up.profile = User.where(email: "kira@kira.com").first.profile
 buddy_up.challenge = Challenge.all.sample
 buddy_up.save
 buddy_up.complete!

--- a/db/seeds/partials/_requests.rb
+++ b/db/seeds/partials/_requests.rb
@@ -1,31 +1,31 @@
 # Requests for BuddyUp 1 of 7
 request = Request.new(message: 'Hey, Rails also did not quite click for me. Shall we try this together?')
 request.buddy_up = BuddyUp.where(name: 'It did not come together in Rails.').first
-request.user = User.where(email: "joni@joni.com").first
+request.profile = User.where(email: "joni@joni.com").first.profile
 request.save
 request.denied!
 
 request = Request.new(message: 'I aced Rails so can help you with this.')
 request.buddy_up = BuddyUp.where(name: 'It did not come together in Rails.').first
-request.user = User.where(email: "mitch@mitch.com").first
+request.profile = User.where(email: "mitch@mitch.com").first.profile
 request.save
 request.approved!
 
 request = Request.new(message: 'Can we do this one together?')
 request.buddy_up = BuddyUp.where(name: 'It did not come together in Rails.').first
-request.user = User.where(email: "kira@kira.com").first
+request.profile = User.where(email: "kira@kira.com").first.profile
 request.save
 
 # Requests for BuddyUp 2 of 7
 request = Request.new(message: "Random request to join. I'll be fun, I promise.")
 request.buddy_up = BuddyUp.where(name: 'Random code things!').first
-request.user = User.where(email: "shane@shane.com").first
+request.profile = User.where(email: "shane@shane.com").first.profile
 request.save
 
 # Requests for BuddyUp 3 of 7
 request = Request.new(message: 'I pick you!')
 request.buddy_up = BuddyUp.where(name: 'Pick me, pick me').first
-request.user = User.where(email: "kira@kira.com").first
+request.profile = User.where(email: "kira@kira.com").first.profile
 request.save
 
 # Requests for BuddyUp 4 of 7
@@ -34,7 +34,7 @@ request.save
 # Requests for BuddyUp 5 of 7
 request = Request.new(message: 'I wanna do this, so random!')
 request.buddy_up = BuddyUp.where(name: 'Catching up').first
-request.user = User.where(email: "mitch@mitch.com").first
+request.profile = User.where(email: "mitch@mitch.com").first.profile
 request.save
 
 # Requests for BuddyUp 6 of 7
@@ -43,6 +43,6 @@ request.save
 # Requests for BuddyUp 7 of 7
 request = Request.new(message: 'And I just want to break free!')
 request.buddy_up = BuddyUp.where(name: 'I want to break things').first
-request.user = User.where(email: "shane@shane.com").first
+request.profile = User.where(email: "shane@shane.com").first.profile
 request.save
 request.approved!


### PR DESCRIPTION
## What?

Refactors the app schema to link all models to *Profile* instead of *User* where possible.
Updates the seed files accordingly.

## Why and how?

Since users will have the option to delete their account (which we must honour because of GDPR and POPIA) we should avoid putting much information (besides the personal) in the *User* model, and avoid linking other models to it via *foreign_key* relationships. 

We want to keep our app robust by ensuring *BuddyUps*, *Feedbacks*, etc can continue to exist when the account of the user who created them is deleted. We accomplish this by linking all other models to the *Profile* instead. When the *User* is deleted the *Profile* will remain.

## Notes about displaying user information in views

Firstly, all the relevant models are updated with ```has_one :user, through: :profile``` so that simple calls like ```buddy_up.user``` will continue to work. No code changes are thus necessary in Views and Controllers.

Because of this change, and the risk of the user account not existing anymore, calls to the user properties need to be wrapped, for example instead of:

```buddy_up.user.name```

rather do:

```buddy_up.user ? buddy_up.user.name : ""``` <--- buddy_up.user will evaluate to nil if the user account is gone

... or similar.

## Schema change

### Before

<img width="900" alt="before" src="https://github.com/KIKMAKER/pgp-le-buddy/assets/6637209/86e758c9-9526-467c-a67a-adc6fadddcb6">

### After

<img width="900" alt="after" src="https://github.com/KIKMAKER/pgp-le-buddy/assets/6637209/dba78749-bc00-4527-ac06-f1f10a06f6e9">

## Other changes

Other changes in this pull request include:
- destroy *profile_languages* when destroying *profile*
- add validation for *profile* presence in *buddy_up*