### PR TITLE
Feat/sign up flow

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
  */
 
 @import "bulma";
+@import "font-awesome";
 
 // Fonts
 @import "fonts";
@@ -25,5 +26,5 @@
 
 // Application-wide CSS (will override the above)
 body {
-  font-family: 'Inter', Helvetica, Arial, sans-serif;
+  font-family: "Inter", Helvetica, Arial, sans-serif;
 }

--- a/app/assets/stylesheets/components/_github-sign-in.scss
+++ b/app/assets/stylesheets/components/_github-sign-in.scss
@@ -1,0 +1,6 @@
+.github-sign-in-card {
+  width: 330px;
+  height: 330px;
+  margin: 0 auto;
+  margin-top: 100px;
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -1,2 +1,3 @@
 @import "flashes";
 @import "buddy-card";
+@import "github-sign-in";

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -1,2 +1,3 @@
 @import "dashboard";
 @import "buddy-ups";
+@import "profile";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,11 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+
+  def after_sign_in_path_for(resource)
+    if @user.profile.batch.nil?
+      profile_path(@user.profile)
+    else
+      super
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,8 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
-
+  # This will check if the user has updated their profile when signing in if not redirect them to profile show
   def after_sign_in_path_for(resource)
-    if @user.profile.batch.nil?
+    if @user.registered?
       profile_path(@user.profile)
     else
       super

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
-  # This will check if the user has updated their profile when signing in if not redirect them to profile show
+  # This will check if the user has updated their profile (via the registered enum) when signing in if not redirect them to profile show
   def after_sign_in_path_for(resource)
     if @user.registered?
       profile_path(@user.profile)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -42,6 +42,7 @@ class ProfilesController < ApplicationController
     @profile = Profile.find(params[:id])
     @profile.update(profile_params)
     if @profile.save
+      current_user.active! if current_user.registered?
       render partial: "preview", locals: { profile: @profile }
     else
       @new_profile_language = ProfileLanguage.new

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -42,6 +42,7 @@ class ProfilesController < ApplicationController
     @profile = Profile.find(params[:id])
     @profile.update(profile_params)
     if @profile.save
+      # a user becomes active once they have updated their profile
       current_user.active! if current_user.registered?
       render partial: "preview", locals: { profile: @profile }
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,14 +16,10 @@ class User < ApplicationRecord
       user.name = auth.info.name
       user.github_name = auth.info.nickname
       user.avatar_url = auth.info.image
-      @user = user
+      user.profile = Profile.new
       # If you are using confirmable and the provider(s) you use validate emails,
       # uncomment the line below to skip the confirmation emails.
       # user.skip_confirmation!
     end
-    profile = Profile.new
-    profile.user = @user
-    profile.save
-    return @user
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,11 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: %i[github]
-
-  enum :status, [ :active, :dummy, :away ]
+  # registered: created an account but have not updated their empty profile
+  # acvtive: updated profile with info
+  # dummy: fake account for testing and presentation
+  # away: user not active, hide buddy ups in market place
+  enum :status, { registered: 0, active: 1, dummy: 2, away: 3 }, default: :registered
   has_one :profile
   has_many :social_links, dependent: :destroy
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,25 +1,34 @@
-<h2>Sign up</h2>
+<div class="container is-max-desktop">
+  <div class="card github-sign-in-card">
+    <div class="card-header">
+      <h1 class= "card-header-title">Create an account</h1>
+    </div>
+    <div class="card-content has-text-centered mt-6">
+      <%= render "devise/shared/links" %>
+    </div>
+  </div>
+</div>
 
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: :false }) do |f| %>
-  <%= f.error_notification %>
+<%# commented out as we only want users to sign up via github %>
 
-  <div class="form-inputs">
-    <%= f.input :email,
+<%# simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: :false }) do |f| %>
+  <%# f.error_notification %>
+
+  <%# <div class="form-inputs"> %>
+    <%# f.input :email,
                 required: true,
                 autofocus: true,
                 input_html: { autocomplete: "email" }%>
-    <%= f.input :password,
+    <%# f.input :password,
                 required: true,
                 hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
                 input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
+    <%# f.input :password_confirmation,
                 required: true,
                 input_html: { autocomplete: "new-password" } %>
-  </div>
+  <%# </div> %>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Sign up" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+  <%# <div class="form-actions"> %>
+    <%# f.button :submit, "Sign up" %>
+  <%# </div> %>
+<%# end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,20 +1,28 @@
-<h2>Log in</h2>
 
-<%= simple_form_for(resource, as: resource_name, url: session_path(resource_name), data: { turbo: :false }) do |f| %>
-  <div class="form-inputs">
-    <%= f.input :email,
-                required: false,
-                autofocus: true,
-                input_html: { autocomplete: "email" } %>
-    <%= f.input :password,
-                required: false,
-                input_html: { autocomplete: "current-password" } %>
-    <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
+<div class="container is-max-desktop">
+  <div class="card github-sign-in-card">
+    <div class="card-header">
+      <h1 class= "card-header-title">log In</h1>
+    </div>
+    <div class="card-content has-text-centered">
+    <%# This form is here so development can log in easily, this form will not be in production %>
+    <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name), data: { turbo: :false }) do |f| %>
+      <div class="form-inputs">
+        <%= f.input :email,
+                    required: false,
+                    autofocus: true,
+                    input_html: { autocomplete: "email" } %>
+        <%= f.input :password,
+                    required: false,
+                    input_html: { autocomplete: "current-password" } %>
+        <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
+      </div>
+
+      <div class="form-actions">
+        <%= f.button :submit, "Log in" %>
+      </div>
+    <% end %>
+    <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="form-actions">
-    <%= f.button :submit, "Log in" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,14 +1,29 @@
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= button_to omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: "button is-primary" do %>
+      <span class="icon-text">
+        <span>Sign In With Github</span>
+        <span class="icon">
+          <i class="fa-brands fa-github fa-lg"></i>
+        </span>
+      </span>
+    <% end %>
+  <% end %>
+<% end %>
+<br>
+
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "Log in", new_session_path(resource_name), class: "button is-link" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "Sign up", new_registration_path(resource_name), class: "button is-link" %><br />
 <% end %>
 
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
-<% end %>
+
+<%#  if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%# link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<%# end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
   <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
@@ -16,10 +31,4 @@
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
   <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
-  <% end %>
 <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -2,7 +2,7 @@
   <%- resource_class.omniauth_providers.each do |provider| %>
     <%= button_to omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: "button is-primary" do %>
       <span class="icon-text">
-        <span>Sign In With Github</span>
+        <span>Sign In With GitHub</span>
         <span class="icon">
           <i class="fa-brands fa-github fa-lg"></i>
         </span>

--- a/db/migrate/20230919143333_change_status_default_on_user.rb
+++ b/db/migrate/20230919143333_change_status_default_on_user.rb
@@ -1,0 +1,5 @@
+class ChangeStatusDefaultOnUser < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :users, :status, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_05_082353) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_19_143333) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -127,7 +127,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_05_082353) do
     t.string "provider", limit: 50, default: "", null: false
     t.string "uid", limit: 50, default: "", null: false
     t.string "avatar_url"
-    t.integer "status", default: 0
+    t.integer "status"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -28,16 +28,16 @@ puts "...done."
 puts ""
 
 # Test user account
-User.create(email: "test@test.com", password: "123456", name: "Tester", github_name: "Bot1234", avatar_url: "https://avatars.githubusercontent.com/u/91339335?v=4")
+User.create(email: "test@test.com", password: "123456", name: "Tester", github_name: "Bot1234", avatar_url: "https://avatars.githubusercontent.com/u/91339335?v=4", status: 1)
 puts "Test user created: test@test.com, 123456"
 puts ""
 
 # Users
 puts "Creating Persona users..."
-User.create(email: "shane@shane.com", password: "123456", name: "Shane", github_name: "Shan3", avatar_url: "https://avatars.githubusercontent.com/u/6637209?v=4")
-User.create(email: "joni@joni.com", password: "123456", name: "Joni", github_name: "Jon1", avatar_url: "https://avatars.githubusercontent.com/u/113447311?v=4")
-User.create(email: "mitch@mitch.com", password: "123456", name: "Mitch", github_name: "Mitchy", avatar_url: "https://avatars.githubusercontent.com/u/130841358?v=4")
-User.create(email: "kira@kira.com", password: "123456", name: "Kira", github_name: "Kira49", avatar_url: "https://avatars.githubusercontent.com/u/53060901?v=4")
+User.create(email: "shane@shane.com", password: "123456", name: "Shane", github_name: "Shan3", avatar_url: "https://avatars.githubusercontent.com/u/6637209?v=4", status: 1)
+User.create(email: "joni@joni.com", password: "123456", name: "Joni", github_name: "Jon1", avatar_url: "https://avatars.githubusercontent.com/u/113447311?v=4", status: 1)
+User.create(email: "mitch@mitch.com", password: "123456", name: "Mitch", github_name: "Mitchy", avatar_url: "https://avatars.githubusercontent.com/u/130841358?v=4", status: 1)
+User.create(email: "kira@kira.com", password: "123456", name: "Kira", github_name: "Kira49", avatar_url: "https://avatars.githubusercontent.com/u/53060901?v=4", status: 1)
 puts "...done. #{User.all.count - 1} users created."
 puts ""
 


### PR DESCRIPTION
## Sign Up Flow
Adds Sign Up With GitHub button style
Adds sign up and sign in style
Fixes how new profile is made when signing up with GitHub
adds registered enum to status as new default once a user updates their profile they become active
adds after sign in method to check if user is registered or active, registered user is redirected to profile show, active user follows devise normal method

## Sign Up

![Screenshot 2023-09-18 190615](https://github.com/KIKMAKER/pgp-le-buddy/assets/91339335/1e17d010-14af-44b4-a2e3-6aed238f2bfb)

## Sign In
I have left the inputs as is, since they just there for us to sign into our seed users
It might be possible to just have one sign up/ sign in page, as the Omniauth method uses first or create to log in with GitHub.

![Screenshot 2023-09-18 190641](https://github.com/KIKMAKER/pgp-le-buddy/assets/91339335/04c77b91-bcd6-43b1-8ef2-731149466cb9)

