### PR TITLE
Remove bulma overrides unused

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,7 +25,7 @@
  @import "components/index";
  @import "pages/index";
  // @import "bulma_overrides/my-bulma-theme";
- $navbar-colors: #0E4749;
+//  $navbar-colors: #0E4749;
 
 // Application-wide CSS (will override the above)
 body {

--- a/app/assets/stylesheets/bulma_overrides/_my-bulma-theme.scss
+++ b/app/assets/stylesheets/bulma_overrides/_my-bulma-theme.scss
@@ -1,1 +1,1 @@
-$navbar-background-color: #0E4749
+// $navbar-background-color: #0E4749

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -9,17 +9,17 @@
   background-color: #0E4749;
 }
 
-.navbar-burger {
-  color: #4a4a4a;
-  -moz-appearance: none;
-  -webkit-appearance: none;
-  appearance: none;
-  background: none;
-  border: none;
-  cursor: pointer;
-  display: block;
-  height: 4.25rem;
-  position: relative;
-  width: 3.25rem;
-  margin-left: auto;
-}
+// .navbar-burger {
+//   color: #4a4a4a;
+//   -moz-appearance: none;
+//   -webkit-appearance: none;
+//   appearance: none;
+//   background: none;
+//   border: none;
+//   cursor: pointer;
+//   display: block;
+//   height: 4.25rem;
+//   position: relative;
+//   width: 3.25rem;
+//   margin-left: auto;
+// }

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -9,6 +9,7 @@
   background-color: #0E4749;
 }
 
+
 // .navbar-burger {
 //   color: #4a4a4a;
 //   -moz-appearance: none;
@@ -23,3 +24,34 @@
 //   width: 3.25rem;
 //   margin-left: auto;
 // }
+
+// __ ** POTENTIAL HOVER CHANGE? **https://www.w3schools.com/cssref/sel_hover.php
+// a:hover {
+//   background-color: yellow;
+// }
+// :hover {
+//   css declarations;
+// }
+// p:hover, h1:hover, a:hover {
+//   background-color: yellow;
+// }
+// /* unvisited link */
+// a:link {
+//   color: green;
+// }
+// or
+// /* visited link */
+// a:visited {
+//   color: green;
+// }
+
+// /* mouse over link */
+// a:hover {
+//   color: red;
+// }
+
+// /* selected link */
+// a:active {
+//   color: yellow;
+// }
+// __


### PR DESCRIPTION
We added in Bulma overrides to try get the navbar to change colour -then we realised that all we needed was the correct class name. So I commented out all the places we referenced Bulma and left it in incase we have a broken thing tomorrow. 

I also tried to find the 'on hover' change colour thing but didn't have much success. 